### PR TITLE
fix: return 404 when pros or cons list is empty

### DIFF
--- a/backend/dist/controllers/prosCons.controller.js
+++ b/backend/dist/controllers/prosCons.controller.js
@@ -17,7 +17,7 @@ const getAllProsConsById = (req, res) => __awaiter(void 0, void 0, void 0, funct
         const prosCons = yield proCon_model_1.ProCon.findAll({
             where: { decisionId: id },
         });
-        if (!prosCons) {
+        if (prosCons.length === 0) {
             res.status(404).json({
                 message: "No se han encontrado los pros y contras",
                 success: false,

--- a/backend/src/controllers/prosCons.controller.ts
+++ b/backend/src/controllers/prosCons.controller.ts
@@ -9,7 +9,7 @@ export const getAllProsConsById = async (req: Request, res: Response) => {
       where: { decisionId: id },
     });
 
-    if (!prosCons) {
+    if (prosCons.length === 0) {
       res.status(404).json({
         message: "No se han encontrado los pros y contras",
         success: false,


### PR DESCRIPTION
## Summary
- ensure pros/cons controller returns 404 when no items found

## Testing
- `npm run build`
- `npm test` *(fails: Missing script: "test")*
- `curl -i -H "Cookie: access_token=<token>" http://localhost:5000/api/proscons/123` *(500 Error de autenticación)*

------
https://chatgpt.com/codex/tasks/task_e_68a8aa744e6c8331b42683ca1b42a472