### PR TITLE
fix: remove duplicate filteredDecisionIds

### DIFF
--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -66,8 +66,6 @@ const Analytics = () => {
     }, []);
 
     const filteredDecisionIds = new Set(filteredEvaluations.map((e) => e.decisionId)); // evita que se repita el filtro en cada renderizado
-
-    const filteredDecisionIds = new Set(filteredEvaluations.map((e) => e.decisionId));
     const filteredDecisions = decisions.filter((d) => filteredDecisionIds.has(d.id));
     const numberOfDecisions = filteredDecisions.length;
 


### PR DESCRIPTION
## Summary
- remove duplicate filteredDecisionIds declaration in Analytics page

## Testing
- `npm run lint` *(fails: Config at index 1 has an 'extends' array that contains a string)*
- `npm run build` *(fails: Analytics.tsx(85,17) Argument expression expected)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ac57e1ec83319c949a60741af67f