### PR TITLE
fix: remove redundant decision mapping in analytics

### DIFF
--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -27,22 +27,13 @@ const Analytics = () => {
                 selectedCategory === 'Todas las categorías' ||
                 decision.category === selectedCategory;
 
-            // Es una funcion que se ejecuta inmediatamente
             const inDateRange = (() => {
                 if (selectedTimeRange === 'Todo') return true;
-                const days = parseInt(selectedTimeRange); // convierte el rango a días integer
+                const days = parseInt(selectedTimeRange); // convierte el rango a días entero
                 const evaluationDate = new Date(evaluation.createdAt);
                 const limitDate = new Date();
-                limitDate.setDate(limitDate.getDate() - days); // Resta days al día actual para obtener una fecha límite.
+                limitDate.setDate(limitDate.getDate() - days); // Resta días al día actual para obtener una fecha límite.
                 return evaluationDate >= limitDate; // Devuelve true si la fecha de la evaluación es igual o posterior a esa fecha límite
-
-            const inDateRange = (() => {
-                if (selectedTimeRange === 'Todo') return true;
-                const days = parseInt(selectedTimeRange);
-                const evaluationDate = new Date(evaluation.createdAt);
-                const limitDate = new Date();
-                limitDate.setDate(limitDate.getDate() - days);
-                return evaluationDate >= limitDate;
             })();
 
             return inCategory && inDateRange;
@@ -65,8 +56,6 @@ const Analytics = () => {
         fetchData();
     }, []);
 
-    const filteredDecisionIds = new Set(filteredEvaluations.map((e) => e.decisionId)); // evita que se repita el filtro en cada renderizado
-
     const filteredDecisionIds = new Set(filteredEvaluations.map((e) => e.decisionId));
     const filteredDecisions = decisions.filter((d) => filteredDecisionIds.has(d.id));
     const numberOfDecisions = filteredDecisions.length;
@@ -81,9 +70,6 @@ const Analytics = () => {
         const timeDiffs = filteredEvaluations
             .map((evaluation) => {
                 // para cada evaluacion, busca la decision correspondiente
-                const decision = decisions.find(
-                    // busca la decision que coincida con el id de la evaluacion
-
                 const decision = decisions.find(
                     (d) => String(d.id) === String(evaluation.decisionId)
                 );
@@ -104,24 +90,12 @@ const Analytics = () => {
 
                 return diffInDays >= 0 ? diffInDays : null;
             })
-            // es un type predicate en TypeScript que le dice al compilador que después del filtro, d es definitivamente un number y no null.
-                if (isNaN(createdDecision.getTime()) || isNaN(createdEvaluation.getTime()))
-                    return null;
-
-                const diffInDays =
-                    (createdEvaluation.getTime() - createdDecision.getTime()) /
-                    (1000 * 60 * 60 * 24);
-
-                return diffInDays >= 0 ? diffInDays : null;
-            })
             .filter((d): d is number => d !== null);
 
         if (timeDiffs.length === 0) return 0;
 
         const sum = timeDiffs.reduce((acc, curr) => acc + curr, 0); // suma los elementos del array empezando desde 0
         // Devuelve el promedio dividiendo la suma entre la cantidad de elementos
-
-        const sum = timeDiffs.reduce((acc, curr) => acc + curr, 0); 
         return sum / timeDiffs.length;
     }, [evaluations, decisions]);
 
@@ -147,15 +121,11 @@ const Analytics = () => {
         const evaluationsByMonth: Record<string, Evaluation[]> = recentEvaluations.reduce(
             (acc, evaluation) => {
                 const month = new Date(evaluation.createdAt).toISOString().slice(0, 7); // saca el mes y año (los ultimos siete digitos)
-                const month = new Date(evaluation.createdAt).toISOString().slice(0, 7);
- 
                 if (!acc[month]) acc[month] = [];
                 acc[month].push(evaluation);
                 return acc;
             },
             {} as Record<string, Evaluation[]> // esto es el valor inicial del reduce
-
-            {} as Record<string, Evaluation[]>
         );
 
         const successRateByMonth = Object.entries(evaluationsByMonth).map(


### PR DESCRIPTION
## Summary
- tidy Analytics filter with single date range computation
- remove duplicate decision lookup and day difference math in decision time average

## Testing
- `npm run build` *(fails: File name differs only in casing, missing exports in Decision types)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ac58e4548331a73ae23631dee7f5