### PR TITLE
feat: secure cookies in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ La **Plataforma de Gestión de Decisiones Personales** es una aplicación web qu
 
 El backend debería estar corriendo en http://localhost:5000.
 
+### Consideraciones de producción
+
+Para despliegues en producción es necesario servir el backend sobre **HTTPS**,
+ya que las cookies de autenticación utilizan las opciones `secure` y
+`sameSite: 'none'` y solo se enviarán a través de conexiones seguras.
+
 
 
 ### Frontend

--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -3,6 +3,8 @@ import { User } from "../models/user.model";
 import bcrypt from "bcryptjs";
 import { generateAccessJWT } from "../utils/generateAccessJWT";
 
+const isProd = process.env.NODE_ENV === "production";
+
 export const login = async (req: Request, res: Response) => {
   const { email } = req.body;
 
@@ -36,8 +38,8 @@ export const login = async (req: Request, res: Response) => {
   let options = {
     maxAge: 60 * 60 * 1000,
     httpOnly: true,
-    secure: false,
-    sameSite: "lax" as const,
+    secure: isProd,
+    sameSite: (isProd ? "none" : "lax") as "none" | "lax",
   };
   const token = generateAccessJWT({ id: existingUser.id });
   res.cookie("access_token", token, options);
@@ -53,8 +55,8 @@ export const login = async (req: Request, res: Response) => {
 export const logout = (_req: Request, res: Response) => {
   res.clearCookie("access_token", {
     httpOnly: true,
-    secure: false,
-    sameSite: "lax",
+    secure: isProd,
+    sameSite: isProd ? "none" : "lax",
   });
   res
     .status(200)


### PR DESCRIPTION
## Summary
- set cookie security options based on NODE_ENV
- document HTTPS requirement for production deployments

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8bb85228483318f94efe89a14ad53