### PR TITLE
refactor: remove user id from creation data

### DIFF
--- a/backend/dist/controllers/user.controller.js
+++ b/backend/dist/controllers/user.controller.js
@@ -21,7 +21,15 @@ dotenv_1.default.config();
 const createUser = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
     try {
         const avatarUrl = req.file ? req.file.filename : "";
-        const user = yield user_service_1.userService.createUser(Object.assign(Object.assign({}, req.body), { avatar: avatarUrl }));
+        const { name, lastName, email, password, birthDate } = req.body;
+        const user = yield user_service_1.userService.createUser({
+            name,
+            lastName,
+            email,
+            password,
+            birthDate,
+            avatar: avatarUrl,
+        });
         res
             .status(201)
             .json({ message: "Usuario creado con éxito", data: user, success: true });

--- a/backend/src/controllers/user.controller.ts
+++ b/backend/src/controllers/user.controller.ts
@@ -9,8 +9,13 @@ dotenv.config();
 export const createUser = async (req: Request, res: Response) => {
   try {
     const avatarUrl = req.file ? req.file.filename : "";
+    const { name, lastName, email, password, birthDate } = req.body;
     const user = await userService.createUser({
-      ...req.body,
+      name,
+      lastName,
+      email,
+      password,
+      birthDate,
       avatar: avatarUrl,
     });
     res

--- a/backend/src/services/user.service.ts
+++ b/backend/src/services/user.service.ts
@@ -7,7 +7,6 @@ dotenv.config();
 
 export const userService = {
   createUser: async (userData: {
-    id: string;
     name: string;
     lastName: string;
     email: string;


### PR DESCRIPTION
## Summary
- remove unused `id` from userService.createUser data
- pass only specific fields from request body when creating user

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a8bb870f908331bffcf83418b52956