### PR TITLE
Read CORS origins from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ La **Plataforma de Gestión de Decisiones Personales** es una aplicación web qu
    ```
 
 4. Configura las variables de entorno:
-   
-- Crea un archivo .env en la raíz del proyecto y agrega las siguientes variables:
+
+- Crea un archivo `.env` en la raíz del proyecto (puedes usar `.env.example` como base) y agrega las siguientes variables:
 
     ```bash
     SALT=10
@@ -73,6 +73,7 @@ La **Plataforma de Gestión de Decisiones Personales** es una aplicación web qu
     DB_NAME=tu_base_datos
     DB_USERNAME=tu_usuario
     DB_PWD=tu_contraseña
+    CORS_ORIGINS=http://localhost:5173,http://172.19.0.4:5173
    ```
 
 5. Construye el proyecto TypeScript:

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,7 @@
+SALT=10
+PORT=5000
+JWT_SECRET=your_secret
+DB_NAME=your_database
+DB_USERNAME=your_username
+DB_PWD=your_password
+CORS_ORIGINS=http://localhost:5173,http://172.19.0.4:5173

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -21,9 +21,13 @@ if (!fs.existsSync(uploadsDir)) {
 
 const app = express();
 
+const allowedOrigins = process.env.CORS_ORIGINS
+  ? process.env.CORS_ORIGINS.split(",").map((origin) => origin.trim())
+  : ["http://localhost:5173", "http://172.19.0.4:5173"];
+
 app.use(
   cors({
-    origin: ["http://localhost:5173", "http://172.19.0.4:5173"],
+    origin: allowedOrigins,
     credentials: true,
   })
 );


### PR DESCRIPTION
## Summary
- Configure Express CORS middleware to read origins from `CORS_ORIGINS` env var
- Add `.env.example` template including `CORS_ORIGINS`
- Document new `CORS_ORIGINS` variable in setup guide

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8bb8363908331bbae15622480da24