### PR TITLE
Add login request validation middleware and test

### DIFF
--- a/backend/src/controllers/__tests__/auth.controller.test.ts
+++ b/backend/src/controllers/__tests__/auth.controller.test.ts
@@ -1,0 +1,17 @@
+import request from 'supertest';
+import express from 'express';
+import authRouter from '../../routes/auth.routes';
+
+const app = express();
+app.use(express.json());
+app.use('/api/login', authRouter);
+
+describe('POST /api/login', () => {
+  it('should return 400 for invalid input', async () => {
+    const res = await request(app)
+      .post('/api/login')
+      .send({ email: 'not-an-email', password: '' });
+    expect(res.status).toBe(400);
+  });
+});
+

--- a/backend/src/middlewares/validateRequest.ts
+++ b/backend/src/middlewares/validateRequest.ts
@@ -1,0 +1,16 @@
+import { NextFunction, Request, Response } from "express";
+import { validationResult } from "express-validator";
+
+export const validateRequest = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    res.status(400).json({ errors: errors.array() });
+    return;
+  }
+  next();
+};
+

--- a/backend/src/routes/auth.routes.ts
+++ b/backend/src/routes/auth.routes.ts
@@ -2,6 +2,7 @@ import { Request, Response } from "express";
 import { Router } from "express";
 import { login } from "../controllers/auth.controller";
 import { body } from "express-validator";
+import { validateRequest } from "../middlewares/validateRequest";
 
 const router = Router();
 
@@ -12,6 +13,7 @@ router.post(
     .withMessage("Enter a valid email address")
     .normalizeEmail(),
   body("password").not().isEmpty(),
+  validateRequest,
   login
 );
 


### PR DESCRIPTION
## Summary
- add `validateRequest` middleware to handle express-validator results
- apply middleware to auth login route
- add unit test ensuring invalid login input is rejected

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8bb814c1c833186b266c9cb76ea97