### PR TITLE
feat(frontend): centralize axios config with env base URL

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:5000/api

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -7,6 +7,14 @@ Currently, two official plugins are available:
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
 - [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
 
+## Environment Variables
+
+Create a `.env` file in this directory based on `.env.example` and set the following variable:
+
+- `VITE_API_URL`: Base URL of the backend API (e.g., `http://localhost:5000/api`).
+
+This value is used by the Axios wrapper to route requests.
+
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:

--- a/frontend/src/components/Dashboard/DecisionsTable.tsx
+++ b/frontend/src/components/Dashboard/DecisionsTable.tsx
@@ -2,7 +2,7 @@ import { ChangeEvent, useEffect, useRef, useState } from 'react';
 import { IoEllipsisHorizontalOutline } from 'react-icons/io5';
 import DropDownActions from './DropDownActions';
 import { DecisionData } from '../../types/decision.types';
-import axios from 'axios';
+import api from '../../utils/api';
 import Chip from '../../components/Dashboard/Chip';
 import DecisionForm from '../Decision/DecisionForm';
 import { BsArrowLeft, BsArrowRight } from 'react-icons/bs';
@@ -126,8 +126,8 @@ function DecisionsTable({
     };
 
     useEffect(() => {
-        axios
-            .get('http://localhost:5000/api/decision', { withCredentials: true })
+        api
+            .get('/decision')
             .then((response) => {
                 setData(response.data.decisions);
             })
@@ -153,10 +153,8 @@ function DecisionsTable({
     }, [searchDecision, active, data]);
 
     const deleteDecision = (id: string) => {
-        axios
-            .delete(`http://localhost:5000/api/decision/${id}`, {
-                withCredentials: true,
-            })
+        api
+            .delete(`/decision/${id}`)
             .then((response) => {
                 setMessage(response.data.message);
                 showSnackbar(response.data.message);

--- a/frontend/src/components/Dashboard/Overview.tsx
+++ b/frontend/src/components/Dashboard/Overview.tsx
@@ -6,7 +6,7 @@ import RecentActivity from './RecentActivity';
 import DecisionsTable from './DecisionsTable';
 import AnalyticsResumeCard from './AnalyticsResumeCard';
 import { Evaluation } from '../../types/decision.types';
-import axios from 'axios';
+import api from '../../utils/api';
 import Snackbar from '../SnackBar';
 
 const Overview = () => {
@@ -36,8 +36,8 @@ const Overview = () => {
     }, [modal]);
 
     useEffect(() => {
-        axios
-            .get('http://localhost:5000/api/evaluation', { withCredentials: true })
+        api
+            .get('/evaluation')
             .then((response) => {
                 const data = response.data.data as Evaluation[];
                 setEvaluations(data);

--- a/frontend/src/components/Dashboard/QuickStatsCard.tsx
+++ b/frontend/src/components/Dashboard/QuickStatsCard.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useAnimation } from '../../hooks/useAnimtation';
 import { DecisionData, Evaluation } from '../../types/decision.types';
-import axios from 'axios';
+import api from '../../utils/api';
 
 const QuickStatsCard = ({ refreshTrigger }: { refreshTrigger: number }) => {
     const [data, setData] = useState<DecisionData[] | []>([]);
@@ -24,8 +24,8 @@ const QuickStatsCard = ({ refreshTrigger }: { refreshTrigger: number }) => {
     console.log(data);
 
     useEffect(() => {
-        axios
-            .get('http://localhost:5000/api/decision', { withCredentials: true })
+        api
+            .get('/decision')
             .then((response) => {
                 const decisions = response.data.decisions;
                 setData(decisions);
@@ -37,8 +37,8 @@ const QuickStatsCard = ({ refreshTrigger }: { refreshTrigger: number }) => {
     }, [refreshTrigger]);
     console.log('Evaluations: ', evaluations);
     useEffect(() => {
-        axios
-            .get('http://localhost:5000/api/evaluation', { withCredentials: true })
+        api
+            .get('/evaluation')
             .then((response) => {
                 setEvaluation(response.data.data);
             })

--- a/frontend/src/components/Dashboard/RecentActivity.tsx
+++ b/frontend/src/components/Dashboard/RecentActivity.tsx
@@ -3,17 +3,15 @@ import { useNavigate } from 'react-router-dom';
 import Chip from '../../components/Dashboard/Chip';
 import { DecisionData } from '../../types/decision.types';
 import { useEffect, useState } from 'react';
-import axios from 'axios';
+import api from '../../utils/api';
 
 const RecentActivity = ({ refreshTrigger }: { refreshTrigger: number }) => {
     const [decisions, setDecisions] = useState<DecisionData[]>([]);
     const navigate = useNavigate();
 
     useEffect(() => {
-        axios
-            .get('http://localhost:5000/api/decision', {
-                withCredentials: true,
-            })
+        api
+            .get('/decision')
             .then((response) => {
                 setDecisions(response.data.decisions);
             })

--- a/frontend/src/components/Decision/DecisionForm.tsx
+++ b/frontend/src/components/Decision/DecisionForm.tsx
@@ -1,7 +1,7 @@
 import { Controller, useFieldArray, useForm } from 'react-hook-form';
 import { FaTrash } from 'react-icons/fa';
 import { ProCon } from '../../types/proCon.types';
-import axios from 'axios';
+import api from '../../utils/api';
 import { useEffect, useState } from 'react';
 import { DecisionCategoryType, DecisionData } from '../../types/decision.types';
 import { ImCross } from 'react-icons/im';
@@ -97,10 +97,8 @@ const DecisionForm = ({ isOpen, onClose, decisionId, onMessage }: Props) => {
         if (!decisionId) return;
 
         // Carga la decisión
-        axios
-            .get(`http://localhost:5000/api/decision/${decisionId}`, {
-                withCredentials: true,
-            })
+        api
+            .get(`/decision/${decisionId}`)
             .then((response) => {
                 setDecision(response.data.decision);
             })
@@ -109,10 +107,8 @@ const DecisionForm = ({ isOpen, onClose, decisionId, onMessage }: Props) => {
             });
 
         // Carga los pros y contras
-        axios
-            .get(`http://localhost:5000/api/proscons/${decisionId}`, {
-                withCredentials: true,
-            })
+        api
+            .get(`/proscons/${decisionId}`)
             .then((response) => {
                 setProsCons(response.data.prosCons);
             })
@@ -128,15 +124,11 @@ const DecisionForm = ({ isOpen, onClose, decisionId, onMessage }: Props) => {
 
             if (decisionId) {
                 // editando una decisión existente
-                res = await axios.put(`http://localhost:5000/api/decision/${decisionId}`, data, {
-                    withCredentials: true,
-                });
+                res = await api.put(`/decision/${decisionId}`, data);
                 onMessage?.(res.data.message || 'Decisión actualizada', true);
             } else {
                 // creando una nueva
-                res = await axios.post('http://localhost:5000/api/decision', data, {
-                    withCredentials: true,
-                });
+                res = await api.post('/decision', data);
                 onMessage?.(res.data.message, true);
             }
             if (!decisionId) {

--- a/frontend/src/components/DecisionForm.tsx
+++ b/frontend/src/components/DecisionForm.tsx
@@ -1,6 +1,6 @@
 import { Controller, useFieldArray, useForm } from 'react-hook-form';
 import { FaTrash } from 'react-icons/fa';
-import axios from 'axios';
+import api from '../utils/api';
 import { useEffect, useState } from 'react';
 import { ImCross } from 'react-icons/im';
 import { RxCross1 } from 'react-icons/rx';
@@ -73,10 +73,8 @@ const DecisionForm = ({ isOpen, onClose, decisionId, onMessage }: Props) => {
         if (!decisionId) return;
 
         // Carga la decisión
-        axios
-            .get(`http://localhost:5000/api/decision/${decisionId}`, {
-                withCredentials: true,
-            })
+        api
+            .get(`/decision/${decisionId}`)
             .then((response) => {
                 setDecision(response.data.decision);
             })
@@ -85,10 +83,8 @@ const DecisionForm = ({ isOpen, onClose, decisionId, onMessage }: Props) => {
             });
 
         // Carga los pros y contras
-        axios
-            .get(`http://localhost:5000/api/proscons/${decisionId}`, {
-                withCredentials: true,
-            })
+        api
+            .get(`/proscons/${decisionId}`)
             .then((response) => {
                 setProsCons(response.data.prosCons);
             })
@@ -104,15 +100,11 @@ const DecisionForm = ({ isOpen, onClose, decisionId, onMessage }: Props) => {
 
             if (decisionId) {
                 // editando una decisión existente
-                res = await axios.put(`http://localhost:5000/api/decision/${decisionId}`, data, {
-                    withCredentials: true,
-                });
+                res = await api.put(`/decision/${decisionId}`, data);
                 onMessage?.(res.data.message || 'Decisión actualizada', true);
             } else {
                 // creando una nueva
-                res = await axios.post('http://localhost:5000/api/decision', data, {
-                    withCredentials: true,
-                });
+                res = await api.post('/decision', data);
                 onMessage?.(res.data.message, true);
             }
             if (!decisionId) {

--- a/frontend/src/components/Login/LoginForm.tsx
+++ b/frontend/src/components/Login/LoginForm.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { FormLoginValues, loginFormSchema } from '../../schemas/login.schema';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import axios from 'axios';
+import api from '../../utils/api';
 import Button from '../Button';
 import Input from '../Input';
 import { useNavigate } from 'react-router-dom';
@@ -51,11 +51,10 @@ const LoginForm = () => {
         }
 
         try {
-            await axios.post('http://localhost:5000/api/login', data, {
+            await api.post('/login', data, {
                 headers: {
                     'Content-Type': 'application/json',
                 },
-                withCredentials: true,
             });
 
             setFailedAttempts(0);

--- a/frontend/src/components/QuickStatsCard.tsx
+++ b/frontend/src/components/QuickStatsCard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import axios from 'axios';
+import api from '../utils/api';
 import { DecisionData } from '../types/decision.types';
 import { Evaluation } from '../types/evaluation.types';
 import { useAnimation } from '../hooks/useAnimtation';
@@ -25,8 +25,8 @@ const QuickStatsCard = ({ refreshTrigger }: { refreshTrigger: number }) => {
     console.log(data);
 
     useEffect(() => {
-        axios
-            .get('http://localhost:5000/api/decision', { withCredentials: true })
+        api
+            .get('/decision')
             .then((response) => {
                 const decisions = response.data.decisions;
                 setData(decisions);
@@ -38,8 +38,8 @@ const QuickStatsCard = ({ refreshTrigger }: { refreshTrigger: number }) => {
     }, [refreshTrigger]);
     console.log('Evaluations: ', evaluations);
     useEffect(() => {
-        axios
-            .get('http://localhost:5000/api/evaluation', { withCredentials: true })
+        api
+            .get('/evaluation')
             .then((response) => {
                 setEvaluation(response.data.data);
             })

--- a/frontend/src/components/Register/FormRegister.tsx
+++ b/frontend/src/components/Register/FormRegister.tsx
@@ -5,7 +5,7 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { FormRegisterValues, registerFormSchema } from '../../schemas/register.schema';
 import Button from '../Button';
-import axios from 'axios';
+import api from '../../utils/api';
 import { useState } from 'react';
 import ModalNavBar from '../../modal/ModalNavBar';
 import { useNavigate } from 'react-router-dom';
@@ -46,7 +46,7 @@ const FormRegister = () => {
         }
 
         try {
-            const req = await axios.post('http://localhost:5000/api/register', formData);
+            const req = await api.post('/register', formData);
             setMessage(req.data.message);
             navigate('/login');
         } catch (error: any) {

--- a/frontend/src/components/overview/RecentActivity.tsx
+++ b/frontend/src/components/overview/RecentActivity.tsx
@@ -2,7 +2,7 @@ import { FaArrowRight } from 'react-icons/fa';
 import { useNavigate } from 'react-router-dom';
 import { DecisionData } from '../../types/decision.types';
 import { useEffect, useState } from 'react';
-import axios from 'axios';
+import api from '../../utils/api';
 import Chip from '../Chip';
 
 const RecentActivity = ({ refreshTrigger }: { refreshTrigger: number }) => {
@@ -10,10 +10,8 @@ const RecentActivity = ({ refreshTrigger }: { refreshTrigger: number }) => {
     const navigate = useNavigate();
 
     useEffect(() => {
-        axios
-            .get('http://localhost:5000/api/decision', {
-                withCredentials: true,
-            })
+        api
+            .get('/decision')
             .then((response) => {
                 setDecisions(response.data.decisions);
             })

--- a/frontend/src/components/profile/EditProfileForm.tsx
+++ b/frontend/src/components/profile/EditProfileForm.tsx
@@ -3,7 +3,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import Input from '../../components/Input';
 import Button from '../../components/Button';
-import axios from 'axios';
+import api from '../../utils/api';
 import { useState } from 'react';
 import { useSnackbarStore } from '../../store/snackbarStore';
 import { User } from '../../types/user.types';
@@ -60,8 +60,7 @@ const EditProfileForm = ({ user }: Props) => {
             formData.append('avatar', data.avatar[0]);
         }
         try {
-            const res = await axios.put(`http://localhost:5000/api/users/${user.id}`, formData, {
-                withCredentials: true,
+            const res = await api.put(`/users/${user.id}`, formData, {
                 headers: { 'Content-Type': 'multipart/form-data' },
             });
             showSnackbar(res.data.message || 'Perfil actualizado');
@@ -78,11 +77,7 @@ const EditProfileForm = ({ user }: Props) => {
         }
 
         try {
-            await axios.put(
-                `http://localhost:5000/api/users/${user.id}/password`,
-                { currentPassword, newPassword },
-                { withCredentials: true }
-            );
+            await api.put(`/users/${user.id}/password`, { currentPassword, newPassword });
             const msg = 'Contraseña actualizada';
             showSnackbar(msg);
             setMessage('');
@@ -121,11 +116,7 @@ const EditProfileForm = ({ user }: Props) => {
         }
 
         try {
-            await axios.post(
-                `http://localhost:5000/api/users/${user.id}/password/verify`,
-                { password: currentPassword },
-                { withCredentials: true }
-            );
+            await api.post(`/users/${user.id}/password/verify`, { password: currentPassword });
             setShowCurrentPassModal(false);
             setShowNewPassModal(true);
             setMessage('');

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import api from '../utils/api';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -8,8 +8,8 @@ export const useAuth = () => {
     const navigate = useNavigate();
 
     useEffect(() => {
-        axios
-            .get('http://localhost:5000/api/me', { withCredentials: true })
+        api
+            .get('/me')
             .then((res) => setUser(res.data.user))
             .catch(() => {
                 setUser(null);
@@ -19,7 +19,7 @@ export const useAuth = () => {
 
     const logout = async () => {
         try {
-            await axios.post('http://localhost:5000/api/logout', {}, { withCredentials: true });
+            await api.post('/logout', {});
             setUser(null);
             navigate('/');
         } catch (error) {

--- a/frontend/src/hooks/useUser.ts
+++ b/frontend/src/hooks/useUser.ts
@@ -1,16 +1,13 @@
 // hooks/useUser.ts
 import { useQuery } from '@tanstack/react-query';
+import api from '../utils/api';
 
 export const useUser = () => {
     return useQuery({
         queryKey: ['user'],
         queryFn: async () => {
-            const res = await fetch('http://localhost:5000/api/me', {
-                credentials: 'include',
-            });
-            if (!res.ok) throw new Error('No autorizado');
-            const data = await res.json();
-            return data.user;
+            const res = await api.get('/me');
+            return res.data.user;
         },
     });
 };

--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -8,7 +8,7 @@ import AnalyticsCard from '../components/analytics/AnalyticsCard';
 import LineChartDecisionStats from '../components/analytics/LineChartDecisionStats';
 import TinyBarChart from '../components/analytics/TinyBarChart';
 import { LuCircleAlert, LuTrendingDown, LuTrendingUp } from 'react-icons/lu';
-import axios from 'axios';
+import api from '../utils/api';
 import { DecisionData } from '../types/decision.types';
 import { Evaluation } from '../types/evaluation.types';
 
@@ -45,8 +45,8 @@ const Analytics = () => {
         const fetchData = async () => {
             try {
                 const [evalRes, decRes] = await Promise.all([
-                    axios.get('http://localhost:5000/api/evaluation', { withCredentials: true }),
-                    axios.get('http://localhost:5000/api/decision', { withCredentials: true }),
+                    api.get('/evaluation'),
+                    api.get('/decision'),
                 ]);
                 setEvaluations(evalRes.data.data);
                 setDecisions(decRes.data.decisions);

--- a/frontend/src/pages/Analytics/Analytics.tsx
+++ b/frontend/src/pages/Analytics/Analytics.tsx
@@ -7,7 +7,7 @@ import AnalyticsResumeCard from '../../components/Dashboard/AnalyticsResumeCard'
 import TinyBarChart from './TinyBarChart';
 import LineChartDecisionStats from './LineChartDecisionStats';
 import { LuCircleAlert, LuTrendingDown, LuTrendingUp } from 'react-icons/lu';
-import axios from 'axios';
+import api from '../../utils/api';
 import { DecisionData } from '../../types/decision.types';
 import { Evaluation } from '../../types/evaluation.types';
 
@@ -68,8 +68,8 @@ const Analytics = () => {
         const fetchData = async () => {
             try {
                 const [evalRes, decRes] = await Promise.all([
-                    axios.get('http://localhost:5000/api/evaluation', { withCredentials: true }),
-                    axios.get('http://localhost:5000/api/decision', { withCredentials: true }),
+                    api.get('/evaluation'),
+                    api.get('/decision'),
                 ]);
                 setEvaluations(evalRes.data.data);
                 setDecisions(decRes.data.decisions);

--- a/frontend/src/pages/Analytics/LineChartDecisionStats.tsx
+++ b/frontend/src/pages/Analytics/LineChartDecisionStats.tsx
@@ -48,8 +48,8 @@ const LineChartDecisionStats = ({ evaluations }: { evaluations: Evaluation[] }) 
     );
 
     // useEffect(() => {
-    //     axios
-    //         .get('http://localhost:5000/api/evaluation', { withCredentials: true })
+    //     api
+    //         .get('/evaluation')
     //         .then((response) => {
     //             const data = response.data.data as Evaluation[];
     //             // setEvaluation(data);

--- a/frontend/src/pages/DecisionDetails.tsx
+++ b/frontend/src/pages/DecisionDetails.tsx
@@ -1,6 +1,6 @@
 import { useNavigate, useParams } from 'react-router-dom';
 import { useEffect, useState } from 'react';
-import axios from 'axios';
+import api from '../utils/api';
 import { HiOutlineMenuAlt3 } from 'react-icons/hi';
 import { IoMdCheckmarkCircleOutline } from 'react-icons/io';
 import { BsPencilSquare } from 'react-icons/bs';
@@ -49,9 +49,7 @@ const DecisionDetails = () => {
     }, [modal]);
 
     useEffect(() => {
-        const res = axios.get(`http://localhost:5000/api/proscons/${id}`, {
-            withCredentials: true,
-        });
+        const res = api.get(`/proscons/${id}`);
         res.then((response) => {
             setProsCons(response.data.prosCons);
             console.log(response.data.prosCons);
@@ -61,10 +59,8 @@ const DecisionDetails = () => {
     }, [id]);
 
     const fetchDecision = () => {
-        axios
-            .get(`http://localhost:5000/api/decision/${id}`, {
-                withCredentials: true,
-            })
+        api
+            .get(`/decision/${id}`)
             .then((response) => {
                 const decision = response.data.decision;
                 setDecision(decision);
@@ -80,9 +76,7 @@ const DecisionDetails = () => {
     }, [id]);
 
     const deleteDecision = () => {
-        const res = axios.delete(`http://localhost:5000/api/decision/${id}`, {
-            withCredentials: true,
-        });
+        const res = api.delete(`/decision/${id}`);
         res.then((response) => {
             setMessage(response.data.message);
             showSnackbar(response.data.message);
@@ -93,10 +87,8 @@ const DecisionDetails = () => {
     };
 
     useEffect(() => {
-        axios
-            .get(`http://localhost:5000/api/evaluation/${id}`, {
-                withCredentials: true,
-            })
+        api
+            .get(`/evaluation/${id}`)
             .then((res) => {
                 setEvaluation(res.data.data);
             })

--- a/frontend/src/pages/DecisionDetails/DecisionDetails.tsx
+++ b/frontend/src/pages/DecisionDetails/DecisionDetails.tsx
@@ -1,7 +1,7 @@
 import { useNavigate, useParams } from 'react-router-dom';
 import { DecisionData, Evaluation } from '../../types/decision.types';
 import { useEffect, useState } from 'react';
-import axios from 'axios';
+import api from '../../utils/api';
 import Chip from '../../components/Dashboard/Chip';
 import { ProCon } from '../../types/proCon.types';
 import { HiOutlineMenuAlt3 } from 'react-icons/hi';
@@ -49,9 +49,7 @@ const DecisionDetails = () => {
     }, [modal]);
 
     useEffect(() => {
-        const res = axios.get(`http://localhost:5000/api/proscons/${id}`, {
-            withCredentials: true,
-        });
+        const res = api.get(`/proscons/${id}`);
         res.then((response) => {
             setProsCons(response.data.prosCons);
             console.log(response.data.prosCons);
@@ -61,10 +59,8 @@ const DecisionDetails = () => {
     }, [id]);
 
     const fetchDecision = () => {
-        axios
-            .get(`http://localhost:5000/api/decision/${id}`, {
-                withCredentials: true,
-            })
+        api
+            .get(`/decision/${id}`)
             .then((response) => {
                 const decision = response.data.decision;
                 setDecision(decision);
@@ -80,9 +76,7 @@ const DecisionDetails = () => {
     }, [id]);
 
     const deleteDecision = () => {
-        const res = axios.delete(`http://localhost:5000/api/decision/${id}`, {
-            withCredentials: true,
-        });
+        const res = api.delete(`/decision/${id}`);
         res.then((response) => {
             setMessage(response.data.message);
             showSnackbar(response.data.message);
@@ -93,10 +87,8 @@ const DecisionDetails = () => {
     };
 
     useEffect(() => {
-        axios
-            .get(`http://localhost:5000/api/evaluation/${id}`, {
-                withCredentials: true,
-            })
+        api
+            .get(`/evaluation/${id}`)
             .then((res) => {
                 setEvaluation(res.data.data);
             })

--- a/frontend/src/pages/Evaluation.tsx
+++ b/frontend/src/pages/Evaluation.tsx
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import api from '../utils/api';
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { Controller, useForm } from 'react-hook-form';
@@ -60,15 +60,15 @@ const Evaluation = () => {
     const finalScore = Math.max(1, Math.round(weighted));
 
     useEffect(() => {
-        axios
-            .get(`http://localhost:5000/api/proscons/${id}`, { withCredentials: true })
+        api
+            .get(`/proscons/${id}`)
             .then((res) => setProsCons(res.data.prosCons))
             .catch((err) => console.error('Error fetching pros and cons:', err));
     }, [id]);
 
     useEffect(() => {
-        axios
-            .get(`http://localhost:5000/api/decision/${id}`, { withCredentials: true })
+        api
+            .get(`/decision/${id}`)
             .then((res) => setDecision(res.data.decision))
             .catch((err) => console.error('Error fetching decision details:', err));
     }, [id]);
@@ -101,23 +101,19 @@ const Evaluation = () => {
         try {
             if (!decision?.id) return;
 
-            const response = await axios.post(
-                'http://localhost:5000/api/evaluation',
+            const response = await api.post(
+                '/evaluation',
                 {
                     result: data.notes,
                     score: finalScore,
                     decisionId: decision.id,
                 },
-                { withCredentials: true }
             );
-            await axios.patch(
-                `http://localhost:5000/api/decision/${decision.id}`,
+            await api.patch(
+                `/decision/${decision.id}`,
                 {
                     status: 'evaluated',
                 },
-                {
-                    withCredentials: true,
-                }
             );
             showSnackbar(response.data.message);
             setMessage(response.data.message);
@@ -128,11 +124,7 @@ const Evaluation = () => {
             setTotalPercentage(0);
 
             navigate(`/dashboard/decisions/${decision.id}`);
-            await axios.post(
-                'http://localhost:5000/api/recommendation',
-                { decisionId: decision.id },
-                { withCredentials: true }
-            );
+            await api.post('/recommendation', { decisionId: decision.id });
         } catch (error: any) {
             showSnackbar(error);
             setMessage('Error al crear evaluación');

--- a/frontend/src/pages/Evaluation/Evaluation.tsx
+++ b/frontend/src/pages/Evaluation/Evaluation.tsx
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import api from '../../utils/api';
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { ProCon } from '../../types/proCon.types';
@@ -60,15 +60,15 @@ const Evaluation = () => {
     const finalScore = Math.max(1, Math.round(weighted));
 
     useEffect(() => {
-        axios
-            .get(`http://localhost:5000/api/proscons/${id}`, { withCredentials: true })
+        api
+            .get(`/proscons/${id}`)
             .then((res) => setProsCons(res.data.prosCons))
             .catch((err) => console.error('Error fetching pros and cons:', err));
     }, [id]);
 
     useEffect(() => {
-        axios
-            .get(`http://localhost:5000/api/decision/${id}`, { withCredentials: true })
+        api
+            .get(`/decision/${id}`)
             .then((res) => setDecision(res.data.decision))
             .catch((err) => console.error('Error fetching decision details:', err));
     }, [id]);
@@ -101,23 +101,19 @@ const Evaluation = () => {
         try {
             if (!decision?.id) return;
 
-            const response = await axios.post(
-                'http://localhost:5000/api/evaluation',
+            const response = await api.post(
+                '/evaluation',
                 {
                     result: data.notes,
                     score: finalScore,
                     decisionId: decision.id,
                 },
-                { withCredentials: true }
             );
-            await axios.patch(
-                `http://localhost:5000/api/decision/${decision.id}`,
+            await api.patch(
+                `/decision/${decision.id}`,
                 {
                     status: 'evaluated',
                 },
-                {
-                    withCredentials: true,
-                }
             );
             showSnackbar(response.data.message);
             setMessage(response.data.message);
@@ -128,11 +124,7 @@ const Evaluation = () => {
             setTotalPercentage(0);
 
             navigate(`/dashboard/decisions/${decision.id}`);
-            await axios.post(
-                'http://localhost:5000/api/recommendation',
-                { decisionId: decision.id },
-                { withCredentials: true }
-            );
+            await api.post('/recommendation', { decisionId: decision.id });
         } catch (error: any) {
             showSnackbar(error);
             setMessage('Error al crear evaluación');

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import axios from 'axios';
+import api from '../utils/api';
 import { useNavigate } from 'react-router-dom';
 import { FormLoginValues, loginFormSchema } from '../schemas/login.schema';
 import ModalNavBar from '../modal/ModalNavBar';
@@ -51,11 +51,10 @@ const LoginForm = () => {
         }
 
         try {
-            await axios.post('http://localhost:5000/api/login', data, {
+            await api.post('/login', data, {
                 headers: {
                     'Content-Type': 'application/json',
                 },
-                withCredentials: true,
             });
 
             setFailedAttempts(0);

--- a/frontend/src/pages/Overview.tsx
+++ b/frontend/src/pages/Overview.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import axios from 'axios';
+import api from '../utils/api';
 import AnalyticsResumeCard from '../components/AnalyticsResumeCard';
 import QuickStatsCard from '../components/QuickStatsCard';
 import NewDecisionButton from '../components/NewDecisionButton';
@@ -37,8 +37,8 @@ const Overview = () => {
     }, [modal]);
 
     useEffect(() => {
-        axios
-            .get('http://localhost:5000/api/evaluation', { withCredentials: true })
+        api
+            .get('/evaluation')
             .then((response) => {
                 const data = response.data.data as Evaluation[];
                 setEvaluations(data);

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import axios from 'axios';
+import api from '../utils/api';
 import { User } from '../types/user.types';
 import EditProfileForm from '../components/profile/EditProfileForm';
 
@@ -8,9 +8,7 @@ const Profile = () => {
     useEffect(() => {
         const fetchUser = async () => {
             try {
-                const res = await axios.get('http://localhost:5000/api/me', {
-                    withCredentials: true,
-                });
+                const res = await api.get('/me');
 
                 setUser(res.data.user);
             } catch (error: any) {

--- a/frontend/src/pages/Profile/EditProfileForm.tsx
+++ b/frontend/src/pages/Profile/EditProfileForm.tsx
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import Input from '../../components/Input';
 import InputFile from '../../components/Register/InputFile';
 import Button from '../../components/Button';
-import axios from 'axios';
+import api from '../../utils/api';
 import { useState } from 'react';
 import type { User } from '../../types/user.types';
 import { useSnackbarStore } from '../../store/snackbarStore';
@@ -60,8 +60,7 @@ const EditProfileForm = ({ user }: Props) => {
             formData.append('avatar', data.avatar[0]);
         }
         try {
-            const res = await axios.put(`http://localhost:5000/api/users/${user.id}`, formData, {
-                withCredentials: true,
+            const res = await api.put(`/users/${user.id}`, formData, {
                 headers: { 'Content-Type': 'multipart/form-data' },
             });
             showSnackbar(res.data.message || 'Perfil actualizado');
@@ -78,11 +77,7 @@ const EditProfileForm = ({ user }: Props) => {
         }
 
         try {
-            await axios.put(
-                `http://localhost:5000/api/users/${user.id}/password`,
-                { currentPassword, newPassword },
-                { withCredentials: true }
-            );
+            await api.put(`/users/${user.id}/password`, { currentPassword, newPassword });
             const msg = 'Contraseña actualizada';
             showSnackbar(msg);
             setMessage('');
@@ -121,11 +116,7 @@ const EditProfileForm = ({ user }: Props) => {
         }
 
         try {
-            await axios.post(
-                `http://localhost:5000/api/users/${user.id}/password/verify`,
-                { password: currentPassword },
-                { withCredentials: true }
-            );
+            await api.post(`/users/${user.id}/password/verify`, { password: currentPassword });
             setShowCurrentPassModal(false);
             setShowNewPassModal(true);
             setMessage('');

--- a/frontend/src/pages/Profile/Profile.tsx
+++ b/frontend/src/pages/Profile/Profile.tsx
@@ -1,16 +1,14 @@
 import EditProfileForm from './EditProfileForm';
 import type { User } from '../../types/user.types';
 import { useEffect, useState } from 'react';
-import axios from 'axios';
+import api from '../../utils/api';
 
 const Profile = () => {
     const [user, setUser] = useState<User | null>(null);
     useEffect(() => {
         const fetchUser = async () => {
             try {
-                const res = await axios.get('http://localhost:5000/api/me', {
-                    withCredentials: true,
-                });
+                const res = await api.get('/me');
 
                 setUser(res.data.user);
             } catch (error: any) {

--- a/frontend/src/pages/Recomendations/Recommendations.tsx
+++ b/frontend/src/pages/Recomendations/Recommendations.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import axios from 'axios';
+import api from '../../utils/api';
 import { FaLightbulb } from 'react-icons/fa';
 
 type Recommendation = {
@@ -18,9 +18,7 @@ const Recommendations = () => {
     useEffect(() => {
         const fetchRecomendations = async () => {
             try {
-                const response = await axios.get('http://localhost:5000/api/recommendation', {
-                    withCredentials: true,
-                });
+                const response = await api.get('/recommendation');
                 setRecomendations(response.data.recommendations.slice(0, 6));
             } catch (err: any) {
                 setError('Error al cargar las recomendaciones');

--- a/frontend/src/pages/Recommendations.tsx
+++ b/frontend/src/pages/Recommendations.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import axios from 'axios';
+import api from '../utils/api';
 import { FaLightbulb } from 'react-icons/fa';
 
 type Recommendation = {
@@ -19,9 +19,7 @@ const Recommendations = () => {
     useEffect(() => {
         const fetchRecomendations = async () => {
             try {
-                const response = await axios.get('http://localhost:5000/api/recommendation', {
-                    withCredentials: true,
-                });
+                const response = await api.get('/recommendation');
                 setRecomendations(response.data.recommendations.slice(0, 6));
             } catch (err: any) {
                 setError('Error al cargar las recomendaciones');

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -1,6 +1,6 @@
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import axios from 'axios';
+import api from '../utils/api';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { FormRegisterValues, registerFormSchema } from '../schemas/register.schema';
@@ -47,7 +47,7 @@ const FormRegister = () => {
         }
 
         try {
-            const req = await axios.post('http://localhost:5000/api/register', formData);
+            const req = await api.post('/register', formData);
             setMessage(req.data.message);
             navigate('/login');
         } catch (error: any) {

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -1,0 +1,8 @@
+import axios from 'axios';
+
+const api = axios.create({
+    baseURL: import.meta.env.VITE_API_URL,
+    withCredentials: true,
+});
+
+export default api;


### PR DESCRIPTION
## Summary
- add reusable Axios instance pulling base URL from `VITE_API_URL`
- use shared client across hooks, components, and pages
- document `VITE_API_URL` and provide example `.env`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Config at index 1 has an 'extends' array that contains a string)*

------
https://chatgpt.com/codex/tasks/task_e_68a8bb7c121c8331a01a50e40e79bffa