### PR TITLE
feat: add DB_SYNC_FORCE option for database sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,11 @@ La **Plataforma de Gestión de Decisiones Personales** es una aplicación web qu
     DB_NAME=tu_base_datos
     DB_USERNAME=tu_usuario
     DB_PWD=tu_contraseña
+    DB_HOST=postgres
+    DB_SYNC_FORCE=false
    ```
+
+   - `DB_SYNC_FORCE`: establece `true` solo si deseas que Sequelize elimine y recree las tablas al iniciar la aplicación.
 
 5. Construye el proyecto TypeScript:
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,8 @@
+SALT=10
+PORT=5000
+JWT_SECRET=tu_secreto
+DB_NAME=tu_base_datos
+DB_USERNAME=tu_usuario
+DB_PWD=tu_contraseña
+DB_HOST=postgres
+DB_SYNC_FORCE=false

--- a/backend/src/config/database.ts
+++ b/backend/src/config/database.ts
@@ -9,6 +9,8 @@ import { Recommendation } from "../models/recommendation.model";
 
 dotenv.config();
 
+const DB_SYNC_FORCE = process.env.DB_SYNC_FORCE === "true";
+
 export const sequelize = new Sequelize({
   database: process.env.DB_NAME,
   username: process.env.DB_USERNAME,
@@ -21,7 +23,7 @@ export const sequelize = new Sequelize({
 export const connectionDB = async () => {
   try {
     await sequelize.authenticate();
-    await sequelize.sync({ force: true });
+    await sequelize.sync({ force: DB_SYNC_FORCE });
     console.log(`Server running at http://localhost:${process.env.PORT}/`);
   } catch (error: any) {
     console.log("Error al conectarse a la BD", error.message);


### PR DESCRIPTION
## Summary
- make Sequelize respect `DB_SYNC_FORCE` env var when syncing
- add example environment configuration
- document `DB_SYNC_FORCE` usage

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8bb7f10808331aeb9c9d3f82b4f49